### PR TITLE
Removed fs from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "@types/node": "^13.1.8",
     "create-index": "^2.6.0",
-    "fs": "0.0.1-security",
     "typed-rest-client": "^1.7.1"
   },
   "devDependencies": {
@@ -42,6 +41,6 @@
     "jest": "^24.9.0",
     "tmp": "^0.1.0",
     "ts-jest": "^24.3.0",
-    "typescript": "^3.7.4"
+    "typescript": "^4.9.3"
   }
 }


### PR DESCRIPTION
Fs shouldn't be in dependencies it's built into node (also it's only used for jest testing so even if it wasn't it should be in dev dependencies). Also updated ts version to match dependencies, as babel__traverse errors on lower ts versions.

The reason I removed FS is because it's causing errors when used with other packages that need fs (such as vite).